### PR TITLE
fix infinite supply mint issue

### DIFF
--- a/src/MicroLend.sol
+++ b/src/MicroLend.sol
@@ -62,10 +62,7 @@ contract Manager {
           (unrealizedInterestFractions + pendingGlobalInterestFractions());
       lToken.totalSupply() == 0
         ? lTokenAmount = amount
-        : lTokenAmount = FixedPointMathLib.unsafeDivUp(
-            amount * lToken.totalSupply() * INTEREST_DIVISOR,
-            totalUsdcFractions
-          );
+        : lTokenAmount = amount * lToken.totalSupply() * INTEREST_DIVISOR \ totalUsdcFractions
       lToken.mint(msg.sender, lTokenAmount);
     }
 


### PR DESCRIPTION
All the debt and unrealized interest are now monitored to be added to the total USDC deposited for the purposes of minting tokens. The calculations are in fractions not to lose any precision, and the deposit/withdraw calculations are also without precision loss beyond what's necessary. The interest accrued is now rounded up.